### PR TITLE
修复 Running Mode 运行时报错的问题

### DIFF
--- a/Tools/RunningMode/running-mode.js
+++ b/Tools/RunningMode/running-mode.js
@@ -53,6 +53,8 @@ $done();
 
 function manager() {
   let ssid;
+  let mode;
+
   if (isSurge) {
     const v4_ip = $network.v4.primaryAddress;
     // no network connection
@@ -61,7 +63,7 @@ function manager() {
       return;
     }
     ssid = $network.wifi.ssid;
-    const mode = ssid ? lookupSSID(ssid) : config.cellular;
+    mode = ssid ? lookupSSID(ssid) : config.cellular;
     const target = {
       RULE: "rule",
       PROXY: "global-proxy",
@@ -71,7 +73,7 @@ function manager() {
   } else if (isLoon) {
     const conf = JSON.parse($config.getConfig());
     ssid = conf.ssid;
-    const mode = ssid ? lookupSSID(ssid) : config.cellular;
+    mode = ssid ? lookupSSID(ssid) : config.cellular;
     const target = {
       DIRECT: 0,
       RULE: 1,
@@ -109,5 +111,3 @@ function notify(title, subtitle, content) {
     $notification.post(title, subtitle, content);
   }
 }
-
-notify("title", "subtitle", "content");


### PR DESCRIPTION
## 做了以下 2 处改动

1. 将 `mode` 常量提升到 `manager` 方法顶层作用域，并改为 `let` 声明
2. 删除冗余的方法调用：`notify("title", "subtitle", "content");`

解决了 #43 所提出的问题