### PR TITLE
[Running Mode] 修复了通知节流没有起作用的 Bug

### DIFF
--- a/Tools/RunningMode/running-mode.js
+++ b/Tools/RunningMode/running-mode.js
@@ -100,14 +100,11 @@ function lookupSSID(ssid) {
 }
 
 function notify(title, subtitle, content) {
-  const TIMESTAMP_KEY = "running_mode_notified_time";
-  const THROTTLE_TIME = 3 * 1000;
-  const lastNotifiedTime = $persistentStore.read(THROTTLE_TIME);
-  if (
-    !lastNotifiedTime ||
-    new Date().getTime() - lastNotifiedTime > THROTTLE_TIME
-  ) {
-    $persistentStore.write(new Date().getTime().toString(), TIMESTAMP_KEY);
+  const SUBTITLE_STORE_KEY = "running_mode_notified_subtitle";
+  const lastNotifiedSubtitle = $persistentStore.read(SUBTITLE_STORE_KEY);
+
+  if (!lastNotifiedSubtitle || lastNotifiedSubtitle !== subtitle) {
+    $persistentStore.write(subtitle.toString(), SUBTITLE_STORE_KEY);
     $notification.post(title, subtitle, content);
   }
 }


### PR DESCRIPTION
## 当前运行 Running Mode 时，从蜂窝数据切换到 Wi-Fi 时没有问题，但是当从 Wi-Fi 切换到蜂窝数据时，会瞬间触发多次通知，如下图：

![issue](https://user-images.githubusercontent.com/38807139/98461670-18acb380-21e9-11eb-91b4-2673a75ecbd6.PNG)

## 问题原因

原代码中的 `const lastNotifiedTime = $persistentStore.read(THROTTLE_TIME);` 即读取持久化数据这一行有问题，存的是 `TIMESTAMP_KEY`，但读的却是 `THROTTLE_TIME`，导致 `lastNotifiedTime` 总是为空。

## 改动理由

虽然找到了原因，但是感觉这种节流方式太过武断或是说一刀切了。于是换了一种思路：只有当通知的内容不同了才会通知网络变动，即以下情况会通知：
    1.  蜂窝数据 => Wi-Fi 1
    2. Wi-Fi 1 => Wi-Fi 2
    3. Wi-Fi 2 => 蜂窝数据

以下情况不会触发通知：
    1. Wi-Fi 1 => Wi-Fi 1
    2. 蜂窝数据 => 蜂窝数据（即便是主副卡切换，因为 Running Mode 设置的规则里也无法区分主副卡，是没必要的通知）

我个人体验了一周，认为是比较好的处理方式