### PR TITLE
解决Node读取Js文件未设置编码造成的vm.run()运行报错问题和vm.runInContext()方法不存在造成的运行报错问题

### DIFF
--- a/Tools/MITM/Proxy.js
+++ b/Tools/MITM/Proxy.js
@@ -12,7 +12,7 @@ const vmconfigs = {
       fs: {
         readFileSync(path) {
           try {
-            const data = fs.readFileSync(`${config.general.workspace}/${path}`);
+            const data = fs.readFileSync(`${config.general.workspace}/${path}`, 'utf8');
             return data;
           } catch (err) {
             console.error(err);
@@ -123,7 +123,7 @@ function addRules(proxy, config) {
           console.log(`Script ${script.name} triggered by ${url}`);
           // load the script
           const code = fs.readFileSync(
-            `${config.general.workspace}/${script.path}`
+            `${config.general.workspace}/${script.path}`, 'utf8'
           );
           // request
           const $request = {
@@ -157,7 +157,7 @@ function addRules(proxy, config) {
               $response,
               $context: {},
             };
-            vm.runInContext(code, context);
+            // vm.runInContext(code, context);
             // modify the response
             const $context = {};
             const vm = new NodeVM({


### PR DESCRIPTION
1. 本地Node版本为v12.18.3，根据[Node官方文档](https://nodejs.org/api/fs.html#fsreaddirsyncpath-options)说明, fs.readFileSync(path, endcoding)方法，不传encoding时方法返回的是二进制buffer，126行 vm.run(code) vm运行时会报错。
`If the encoding option is specified then this function returns a string. Otherwise it returns a buffer.`
2. 根据[vm2官方文档](https://github.com/patriksimek/vm2)说明，没有找到 vm.runInContext()方法， 160 行运行报错。
What is the difference between Node's vm and vm2?
```js
const vm = require('vm');
vm.runInNewContext('this.constructor.constructor("return process")().exit()');
const {VM} = require('vm2');
new VM().run('this.constructor.constructor("return process")().exit()');
```