### PR TITLE
为疫情日报添加boxjs

### DIFF
--- a/Tasks/box.js.json
+++ b/Tasks/box.js.json
@@ -460,7 +460,7 @@
     {
       "id": "nCov",
       "name": "疫情监控",
-      "author": "@YangZhaoCool",
+      "author": "@YangZhaocool",
       "repo": "https://github.com/Peng-YM/QuanX",
       "keys": [
         "@nCov.api"
@@ -473,7 +473,7 @@
       "icons": [
         "https://raw.githubusercontent.com/Orz-3/mini/master/Color/COVID-19.png"
       ],
-      "script": "https://raw.githubusercontent.com/YangZhaocool/QuanX-1/master/Tasks/nCov.js"
+      "script": "https://raw.githubusercontent.com/Peng-YM/QuanX/master/Tasks/nCov.js"
     }
   ]
 }

--- a/Tasks/box.js.json
+++ b/Tasks/box.js.json
@@ -8,7 +8,9 @@
     {
       "id": "Github Monitor",
       "name": "GitHub 监控",
-      "keys": ["@github.repo"],
+      "keys": [
+        "@github.repo"
+      ],
       "settings": [
         {
           "id": "@github.repo",
@@ -38,7 +40,9 @@
     {
       "id": "Flow",
       "name": "机场流量查询",
-      "keys": ["@flow.subscriptions"],
+      "keys": [
+        "@flow.subscriptions"
+      ],
       "settings": [
         {
           "id": "@flow.subscriptions",
@@ -61,7 +65,9 @@
     {
       "id": "Steam",
       "name": "Steam 价格监控",
-      "keys": ["@steam.games"],
+      "keys": [
+        "@steam.games"
+      ],
       "settings": [
         {
           "id": "@steam.games",
@@ -84,7 +90,9 @@
     {
       "id": "Zongheng",
       "name": "纵横小说",
-      "keys": ["@zongheng.ids"],
+      "keys": [
+        "@zongheng.ids"
+      ],
       "settings": [
         {
           "id": "@zongheng.ids",
@@ -107,7 +115,10 @@
     {
       "id": "Telegram",
       "name": "Telegram 频道媒体推送",
-      "keys": ["@telegram.channels", "@telegram.maxMedias"],
+      "keys": [
+        "@telegram.channels",
+        "@telegram.maxMedias"
+      ],
       "settings": [
         {
           "id": "@telegram.channels",
@@ -445,6 +456,24 @@
         "https://raw.githubusercontent.com/58xinian/icon/master/telegram_mini.png",
         "https://raw.githubusercontent.com/58xinian/icon/master/telegram.png"
       ]
+    },
+    {
+      "id": "nCov",
+      "name": "疫情监控",
+      "author": "@YangZhaoCool",
+      "repo": "https://github.com/Peng-YM/QuanX",
+      "keys": [
+        "@nCov.api"
+      ],
+      "settings": [
+        {
+          "id": "@nCov.api"
+        }
+      ],
+      "icons": [
+        "https://raw.githubusercontent.com/Orz-3/mini/master/Color/COVID-19.png"
+      ],
+      "script": "https://raw.githubusercontent.com/YangZhaocool/QuanX-1/master/Tasks/nCov.js"
     }
   ]
 }

--- a/Tasks/nCov.js
+++ b/Tasks/nCov.js
@@ -2,6 +2,7 @@
  *  疫情日报，自动获取当前位置的疫情信息
  *  自行申请nCov API，非常简单: https://www.tianapi.com/apiview/169
  *  在boxjs填入申请的API
+ *  boxjs订阅地址： https://raw.githubusercontent.com/Peng-YM/QuanX/master/Tasks/nCov.js
  *  @author: Peng-YM
  *  感谢 @Mazetsz 提供腾讯API接口Token
  *  更新地址: https://raw.githubusercontent.com/Peng-YM/QuanX/master/Tasks/nCov.js

--- a/Tasks/nCov.js
+++ b/Tasks/nCov.js
@@ -1,16 +1,15 @@
 /**
  *  疫情日报，自动获取当前位置的疫情信息
  *  自行申请nCov API，非常简单: https://www.tianapi.com/apiview/169
- *  在12行 nCov_api 填入申请到的API
+ *  在boxjs填入申请的API
  *  @author: Peng-YM
  *  感谢 @Mazetsz 提供腾讯API接口Token
  *  更新地址: https://raw.githubusercontent.com/Peng-YM/QuanX/master/Tasks/nCov.js
  */
 
 const $ = API("nCov");
-
 const tx_key = "NOUBZ-7BNHD-SZ64A-HUWCW-YBGZ7-DDBNK";
-const nCov_api = "5dcf1a3871f36bcc48c543c8193223fc" /* 填入申请的 api */
+const nCov_api = `${$.read("api")}`
 const headers = {
     "User-Agent":
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36",


### PR DESCRIPTION
疫情日报要自个填申请的api 故加入了boxjs支持
疫情日报目前是获取的全国疫情信息 腾讯获取ip属地的作用似乎不大 有空在优化